### PR TITLE
Confine snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,20 @@ Change using `sudo snap openthread-border-router set key="value"`
 
 Connect interfaces to access desired resources:
 ```bash
-# Allow access to system files
+# Allow access to specific system files
 sudo snap connect openthread-border-router:system-etc-iproute
 sudo snap connect openthread-border-router:system-etc-sysctl
 sudo snap connect openthread-border-router:system-run-openthread-wpan0
 
 # Allow DNS-SD registration and discovery
 sudo snap connect openthread-border-router:avahi-control
-# Allow control over the network firewall
+# Allow setting up the firewall
 sudo snap connect openthread-border-router:firewall-control
 # Allow access to all connected USB devices via a raw interface
 sudo snap connect openthread-border-router:raw-usb
-# Allow wide and privileged access to networking
+# Allow setting up the networking
 sudo snap connect openthread-border-router:network-control
-# Allow access to kernel Bluetooth stack
+# Allow controlling the Bluetooth devices
 sudo snap connect openthread-border-router:bluetooth-control
 # Allow device discovery over Bluetooth Low Energy
 sudo snap connect openthread-border-router:bluez

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ sudo snap connect openthread-border-router:system-run-openthread-wpan0
 sudo snap connect openthread-border-router:avahi-control
 # Allow setting up the firewall
 sudo snap connect openthread-border-router:firewall-control
-# Allow access to all connected USB devices via a raw interface
+# Allow access to USB Thread Radio Co-Processor (RCP)
 sudo snap connect openthread-border-router:raw-usb
 # Allow setting up the networking
 sudo snap connect openthread-border-router:network-control
@@ -65,6 +65,8 @@ sudo snap start openthread-border-router
 ```
 
 ## Usage
+
+### Control a Matter Thread device
 To commission and control a Matter Thread device via the OTBR Snap, please refer to the [wiki](https://github.com/MonicaisHer/openthread-border-router-snap/wiki/Commission-and-control-a-Matter-Thread-device-via-the-OTBR-Snap).
 
 ## Viewing logs

--- a/README.md
+++ b/README.md
@@ -31,24 +31,6 @@ thread-if  wpan0
 
 Change using `sudo snap openthread-border-router set key="value"`
 
-> **_NOTE:_**  If the thread interface you are using is different from the default one (wpan0), then you need to add the following [system interface](https://snapcraft.io/docs/system-files-interface) to allow OTBR snap to access system files located in `/run/openthread-<thread-if>.*` during runtime. 
-> 
-> To do this, add the following interface to the plug and otbr-agent app sections in snapcraft.yaml as shown below, then re-build the snap:
-> ```bash
-> plugs:
->   system-run-openthread-<thread-if>:
->     interface: system-files
->       write:
->         - /run/openthread-<thread-if>.lock
->         - /run/openthread-<thread-if>.sock
-> ```
-> ```bash
-> apps:
->   otbr-agent:
->     plugs: 
->         - system-run-openthread-<thread-if>
-> ```
-
 ## Grant access
 
 Connect interfaces to access desired resources:
@@ -72,9 +54,9 @@ sudo snap connect openthread-border-router:bluetooth-control
 sudo snap connect openthread-border-router:bluez
 ```
 
-> **_NOTE:_**  If the thread interface is different from the default one (wpan0), instead of `system-run-openthread-wpan0`, connect:
+> **_NOTE:_**  If the thread interface is different from the default value (wpan0), instead of `system-run-openthread-wpan0`, connect:
 > ```bash
-> sudo snap connect openthread-border-router:system-run-openthread-<thread-if>
+> sudo snap connect openthread-border-router:system-run
 > ```
 
 ## Run

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This will create a snap package file with .snap extension. It can be installed l
 sudo snap install ./openthread-border-router_*.snap --devmode
 ```
 
+## Configure
 View default configurations:
 ```bash
 $ sudo snap get openthread-border-router 
@@ -29,6 +30,60 @@ thread-if  wpan0
 ```
 
 Change using `sudo snap openthread-border-router set key="value"`
+
+> **_NOTE:_**  If the thread interface you are using is different from the default one (wpan0), then you need to add the following [system interface](https://snapcraft.io/docs/system-files-interface) to allow OTBR snap to access system files located in `/run/openthread-<thread-if>.*` during runtime. 
+> 
+> To do this, add the following interface to the plug and otbr-agent app sections in snapcraft.yaml as shown below, then re-build the snap:
+> ```bash
+> plugs:
+>   system-run-openthread-<thread-if>:
+>     interface: system-files
+>       write:
+>         - /run/openthread-<thread-if>.lock
+>         - /run/openthread-<thread-if>.sock
+> ```
+> ```bash
+> apps:
+>   otbr-agent:
+>     plugs: 
+>         - system-run-openthread-<thread-if>
+> ```
+
+## Grant access
+
+Connect interfaces to access desired resources:
+```bash
+# Allow access to system files
+sudo snap connect openthread-border-router:system-etc-iproute
+sudo snap connect openthread-border-router:system-etc-sysctl
+sudo snap connect openthread-border-router:system-run-openthread-wpan0
+
+# Allow DNS-SD registration and discovery
+sudo snap connect openthread-border-router:avahi-control
+# Allow control over the network firewall
+sudo snap connect openthread-border-router:firewall-control
+# Allow access to all connected USB devices via a raw interface
+sudo snap connect openthread-border-router:raw-usb
+# Allow wide and privileged access to networking
+sudo snap connect openthread-border-router:network-control
+# Allow access to kernel Bluetooth stack
+sudo snap connect openthread-border-router:bluetooth-control
+# Allow device discovery over Bluetooth Low Energy
+sudo snap connect openthread-border-router:bluez
+```
+
+> **_NOTE:_**  If the thread interface is different from the default one (wpan0), instead of `system-run-openthread-wpan0`, connect:
+> ```bash
+> sudo snap connect openthread-border-router:system-run-openthread-<thread-if>
+> ```
+
+## Run
+```bash
+sudo snap start openthread-border-router
+```
+
+## Usage
+To commission and control a Matter Thread device via the OTBR Snap, please refer to the [wiki](https://github.com/MonicaisHer/openthread-border-router-snap/wiki/Commission-and-control-a-Matter-Thread-device-via-the-OTBR-Snap).
 
 ## Viewing logs
 ```bash

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,6 +28,8 @@ plugs:
       - /etc/iproute2
       - /etc/sysctl.conf
       - /etc/sysctl.d
+      - /run/openthread-wpan0.lock
+      - /run/openthread-wpan0.sock
 
 layout:
   /usr/share/otbr-web/frontend:
@@ -48,20 +50,10 @@ apps:
     plugs:
       - network
       - network-control
-      - network-observe
       - firewall-control
       - avahi-observe
       - avahi-control
-      - bluetooth-control
-      - bluez
-      - home
       - system-observe
-      - steam-support
-      - ppp
-      - process-control
-      - netlink-audit
-      - netlink-connector
-      - qualcomm-ipc-router
       - etc-files
 
   otbr-agent:
@@ -71,6 +63,15 @@ apps:
     daemon: simple
     install-mode: disable
     # restart-delay: 10s
+    plugs: 
+      - network 
+      - network-control  
+      - firewall-control 
+      - avahi-observe
+      - avahi-control
+      - raw-usb
+      - hardware-observe
+      - etc-files
 
   # Web GUI
   # The default port is 80
@@ -81,9 +82,16 @@ apps:
     daemon: simple
     install-mode: disable
     # restart-delay: 3s
+    plugs:
+      - network
+      - network-bind
+      - etc-files
+    
 
   ot-ctl:
     command: bin/ot-ctl
+    plugs:
+      - etc-files
   
 parts:
   build-bin:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ slots:
     name: io.openthread.BorderRouter.wpan0
 
 plugs:
-  etc-files:
+  system-etc-run-files:
     interface: system-files
     write:
       - /etc/iproute2
@@ -49,12 +49,11 @@ apps:
     install-mode: disable
     plugs:
       - network
+      - network-bind
       - network-control
       - firewall-control
-      - avahi-observe
-      - avahi-control
       - system-observe
-      - etc-files
+      - system-etc-run-files
 
   otbr-agent:
     after:
@@ -65,13 +64,14 @@ apps:
     # restart-delay: 10s
     plugs: 
       - network 
-      - network-control  
-      - firewall-control 
+      - network-bind
+      - network-control
       - avahi-observe
       - avahi-control
+      - bluetooth-control
+      - bluez
       - raw-usb
-      - hardware-observe
-      - etc-files
+      - system-etc-run-files
 
   # Web GUI
   # The default port is 80
@@ -85,13 +85,13 @@ apps:
     plugs:
       - network
       - network-bind
-      - etc-files
+      - system-etc-run-files
     
 
   ot-ctl:
     command: bin/ot-ctl
     plugs:
-      - etc-files
+      - system-etc-run-files
   
 parts:
   build-bin:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,7 +36,10 @@ plugs:
     write:
       - /run/openthread-wpan0.lock
       - /run/openthread-wpan0.sock
-      
+  system-run:
+    interface: system-files
+    write:
+      - /run
 layout:
   /usr/share/otbr-web/frontend:
     symlink: $SNAP/usr/share/otbr-web/frontend
@@ -80,6 +83,7 @@ apps:
       # Access to RCP USB devices
       - raw-usb
       - system-run-openthread-wpan0
+      - system-run
 
   # Web GUI
   # The default port is 80
@@ -94,12 +98,14 @@ apps:
       - network
       - network-bind
       - system-run-openthread-wpan0
+      - system-run
     
 
   ot-ctl:
     command: bin/ot-ctl
     plugs:
       - system-run-openthread-wpan0
+      - system-run
   
 parts:
   build-bin:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,18 +22,24 @@ slots:
     name: io.openthread.BorderRouter.wpan0
 
 plugs:
-  system-config-files:
+  system-etc-iproute:
     interface: system-files
     write:
       - /etc/iproute2
+  system-etc-sysctl:
+    interface: system-files
+    write:
       - /etc/sysctl.conf
       - /etc/sysctl.d
-  system-runtime-files:
+  system-run-openthread-wpan0:
     interface: system-files
     write:
       - /run/openthread-wpan0.lock
       - /run/openthread-wpan0.sock
-
+  system-run:
+    interface: system-files
+    write:
+      - /run
 layout:
   /usr/share/otbr-web/frontend:
     symlink: $SNAP/usr/share/otbr-web/frontend
@@ -55,8 +61,8 @@ apps:
       - network-bind
       - network-control
       - firewall-control
-      - system-observe
-      - system-config-files
+      - system-etc-iproute
+      - system-etc-sysctl
 
   otbr-agent:
     after:
@@ -69,12 +75,13 @@ apps:
       - network 
       - network-bind
       - network-control
-      - avahi-observe
       - avahi-control
+      # Acess bluetooth for device discovery over BLE
       - bluetooth-control
       - bluez
+      # Access to RCP USB devices
       - raw-usb
-      - system-runtime-files
+      - system-run-openthread-wpan0
 
   # Web GUI
   # The default port is 80
@@ -88,13 +95,13 @@ apps:
     plugs:
       - network
       - network-bind
-      - system-runtime-files
+      - system-run-openthread-wpan0
     
 
   ot-ctl:
     command: bin/ot-ctl
     plugs:
-      - system-runtime-files
+      - system-run-openthread-wpan0
   
 parts:
   build-bin:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,18 +21,20 @@ slots:
     bus: system
     name: io.openthread.BorderRouter.wpan0
 
+plugs:
+  etc-files:
+    interface: system-files
+    write:
+      - /etc/iproute2
+      - /etc/sysctl.conf
+      - /etc/sysctl.d
+
 layout:
   /usr/share/otbr-web/frontend:
     symlink: $SNAP/usr/share/otbr-web/frontend
   # This is the default OT_POSIX_SETTINGS_PATH
   /var/lib/thread:
     symlink: $SNAP_COMMON/thread-data
-
-  /etc/sysctl.d:
-    bind: $SNAP/etc/sysctl.d
-  /etc/iproute2:
-    bind: $SNAP/etc/iproute2
-
 
 # hooks:
 #     install:
@@ -60,6 +62,7 @@ apps:
       - netlink-audit
       - netlink-connector
       - qualcomm-ipc-router
+      - etc-files
 
   otbr-agent:
     after:
@@ -142,13 +145,11 @@ parts:
       - libjsoncpp-dev
     override-build: |
       # Setup scripts
+      # Remove sudo from scripts
+      find ./script -type f -exec sed -i 's/sudo //g' {} +
       # TODO: This copies everything, even though most aren't required
       cp -vr ./script $CRAFT_PART_INSTALL/bin/
       chmod +x $CRAFT_PART_INSTALL/bin/script/otbr-firewall
-      # Changes for otbr-setup
-      chmod +x $CRAFT_PART_INSTALL/bin/script/_ipforward
-      sed -i 's/sudo //g' $CRAFT_PART_INSTALL/bin/script/_ipforward
-      sed -i 's/sudo //g' $CRAFT_PART_INSTALL/bin/script/_rt_tables
 
       # TODO: Avoid setting INFRA_IF_NAME here
       # The value is passed to cmake-build and then added to /etc/default/otbr-agent

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,10 +36,7 @@ plugs:
     write:
       - /run/openthread-wpan0.lock
       - /run/openthread-wpan0.sock
-  system-run:
-    interface: system-files
-    write:
-      - /run
+      
 layout:
   /usr/share/otbr-web/frontend:
     symlink: $SNAP/usr/share/otbr-web/frontend

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -76,6 +76,7 @@ apps:
       - network-bind
       - network-control
       - avahi-control
+      - firewall-control
       # Acess bluetooth for device discovery over BLE
       - bluetooth-control
       - bluez

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ architectures:
   - build-on: arm64
 
 grade: devel
-confinement: devmode
+confinement: strict
 
 
 slots:
@@ -28,6 +28,12 @@ layout:
   /var/lib/thread:
     symlink: $SNAP_COMMON/thread-data
 
+  /etc/sysctl.d:
+    bind: $SNAP/etc/sysctl.d
+  /etc/iproute2:
+    bind: $SNAP/etc/iproute2
+
+
 # hooks:
 #     install:
 #         plugs: [network]
@@ -37,6 +43,23 @@ apps:
     command: bin/otbr-setup.sh
     daemon: oneshot
     install-mode: disable
+    plugs:
+      - network
+      - network-control
+      - network-observe
+      - firewall-control
+      - avahi-observe
+      - avahi-control
+      - bluetooth-control
+      - bluez
+      - home
+      - system-observe
+      - steam-support
+      - ppp
+      - process-control
+      - netlink-audit
+      - netlink-connector
+      - qualcomm-ipc-router
 
   otbr-agent:
     after:
@@ -122,6 +145,10 @@ parts:
       # TODO: This copies everything, even though most aren't required
       cp -vr ./script $CRAFT_PART_INSTALL/bin/
       chmod +x $CRAFT_PART_INSTALL/bin/script/otbr-firewall
+      # Changes for otbr-setup
+      chmod +x $CRAFT_PART_INSTALL/bin/script/_ipforward
+      sed -i 's/sudo //g' $CRAFT_PART_INSTALL/bin/script/_ipforward
+      sed -i 's/sudo //g' $CRAFT_PART_INSTALL/bin/script/_rt_tables
 
       # TODO: Avoid setting INFRA_IF_NAME here
       # The value is passed to cmake-build and then added to /etc/default/otbr-agent

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,12 +22,15 @@ slots:
     name: io.openthread.BorderRouter.wpan0
 
 plugs:
-  system-etc-run-files:
+  system-config-files:
     interface: system-files
     write:
       - /etc/iproute2
       - /etc/sysctl.conf
       - /etc/sysctl.d
+  system-runtime-files:
+    interface: system-files
+    write:
       - /run/openthread-wpan0.lock
       - /run/openthread-wpan0.sock
 
@@ -53,7 +56,7 @@ apps:
       - network-control
       - firewall-control
       - system-observe
-      - system-etc-run-files
+      - system-config-files
 
   otbr-agent:
     after:
@@ -71,7 +74,7 @@ apps:
       - bluetooth-control
       - bluez
       - raw-usb
-      - system-etc-run-files
+      - system-runtime-files
 
   # Web GUI
   # The default port is 80
@@ -85,13 +88,13 @@ apps:
     plugs:
       - network
       - network-bind
-      - system-etc-run-files
+      - system-runtime-files
     
 
   ot-ctl:
     command: bin/ot-ctl
     plugs:
-      - system-etc-run-files
+      - system-runtime-files
   
 parts:
   build-bin:


### PR DESCRIPTION
This PR confines the OTBR snap by adding the necessary interfaces to each app:

otbr-setup requires:
- `network`,  `network-bind`, `network-control` and `firewall-control` plugs to set up the network and firewall.
- `system-observe` and `system-config-files` plugs to access system information and config files in order to set up iproute (/etc/sysctl.* and /etc/iproute2).

otbr-agent requires:
-  `network`,  `network-bind`, `network-control plugs to set up the network.
- `avahi-observe` and  `avahi-control` plugs to allow DNS-SD-based discovery.
- `bluetooth-control` and `bluez` plugs for device discovery over Bluetooth Low Energy (BLE).
- `raw-usb` to discover physically connected RCP.
- `system-runtime-files` to access system files (/run/openthread-wpan0.*) during runtime.

otbr-web requires:
- `network`,  `network-bind` plugs to access and operate the network.
- `system-runtime-files` plug to access system files (/run/openthread-wpan0.*) during runtime.

ot-ctl requires:
- `system-runtime-files` plug  to access system files (/run/openthread-wpan0.*) during runtime.

This PR also removes sudo from scripts during build time, to prevent file permission issues during runtime.

## Testing
Build and setup:
```
snapcraft clean && snapcraft -v --debug

sudo snap remove --purge openthread-border-router
sudo snap install ./openthread-border-router_0.1_amd64.snap --dangerous

# set this if your infra interface is different from the default wlp3s0
sudo snap set openthread-border-router infra-if="eno1"

sudo snap connect openthread-border-router:system-etc-iproute
sudo snap connect openthread-border-router:system-etc-sysctl
sudo snap connect openthread-border-router:system-run
sudo snap connect openthread-border-router:system-run-openthread-wpan0

sudo snap connect openthread-border-router:avahi-control
sudo snap connect openthread-border-router:firewall-control
sudo snap connect openthread-border-router:raw-usb
sudo snap connect openthread-border-router:network-control
sudo snap connect openthread-border-router:bluetooth-control
sudo snap connect openthread-border-router:bluez

sudo snap connections openthread-border-router  
```
Start :
```
sudo snap start openthread-border-router
```
Following the steps [here](https://github.com/MonicaisHer/openthread-border-router-snap/wiki/Commission-and-control-a-Matter-Thread-device-via-the-OTBR-Snap#forming-the-otbr-network) to form a Thread Network, then discover and pair the Thread lighting device into the OTBR network:
1. Connect the RCP dongle (A) to a USB port
2. Use the CTL tool to initialize the Thread network:
```
sudo openthread-border-router.ot-ctl
> dataset init new
Done
> dataset commit active
Done
> ifconfig up
Done
> thread start
Done
```
3. Obtaining the OTBR operational dataset (OTBR network's credentials):
```
sudo openthread-border-router.ot-ctl
> dataset active -x
0e08...f7f8
Done
```
4. Discovering and pairing the Thread lighting device into the OTBR network over Bluetooth LE:
```
sudo chip-tool pairing ble-thread 110 hex:0e08...f7f8 20202021 3840
```
